### PR TITLE
Set 'sentForMediaAt' to be null by default

### DIFF
--- a/src/nft-tokens.schema.ts
+++ b/src/nft-tokens.schema.ts
@@ -39,7 +39,7 @@ export class NFTToken {
   @Prop()
   public sentAt: Date;
 
-  @Prop()
+  @Prop({ default: null })
   public sentForMediaAt: Date;
 
   @Prop()


### PR DESCRIPTION
We want `sentForMediaAt` to default to null so that we can query/index it effectively